### PR TITLE
added scheduling treatment, to timestamp check

### DIFF
--- a/main/app_main.c
+++ b/main/app_main.c
@@ -221,6 +221,9 @@ void app_main(void)
 #ifdef CONFIG_MQTT_OPS
     xTaskCreate(ops_pub_task, "ops_pub_task", configMINIMAL_STACK_SIZE * 5, (void *)client, 5, NULL);
 #endif // CONFIG_MQTT_OPS
-    start_scheduler();
+
+    start_scheduler_timer();
+    xTaskCreate(handle_scheduler, "handle_scheduler", configMINIMAL_STACK_SIZE * 3, (void *)client, 5, NULL);
+
   }
 }

--- a/main/app_main.c
+++ b/main/app_main.c
@@ -222,7 +222,6 @@ void app_main(void)
     xTaskCreate(ops_pub_task, "ops_pub_task", configMINIMAL_STACK_SIZE * 5, (void *)client, 5, NULL);
 #endif // CONFIG_MQTT_OPS
 
-    start_scheduler_timer();
     xTaskCreate(handle_scheduler, "handle_scheduler", configMINIMAL_STACK_SIZE * 3, (void *)client, 5, NULL);
 
   }

--- a/main/app_mqtt.h
+++ b/main/app_mqtt.h
@@ -4,7 +4,7 @@
 /* some useful values for relay Json exchanges */
 #define MAX_MQTT_DATA_LEN_RELAY 32
 #define MAX_MQTT_DATA_THERMOSTAT 64
-#define MAX_MQTT_DATA_SCHEDULER 64
+#define MAX_MQTT_DATA_SCHEDULER 96
 #define JSON_BAD_RELAY_VALUE 255
 #define JSON_BAD_TOPIC_ID 255
 
@@ -22,7 +22,7 @@ void handle_mqtt_sub_pub(void* pvParameters);
 char get_relay_json_value(const char* tag, esp_mqtt_event_handle_t event);
 
 
-char get_topic_id(esp_mqtt_event_handle_t event, int maxTopics, const char * topic);
+unsigned char get_topic_id(esp_mqtt_event_handle_t event, int maxTopics, const char * topic);
 
 bool handle_scheduler_mqtt_event(esp_mqtt_event_handle_t event);
 bool handle_relay_cfg_mqtt_event(esp_mqtt_event_handle_t event);

--- a/main/app_mqtt.h
+++ b/main/app_mqtt.h
@@ -5,8 +5,8 @@
 #define MAX_MQTT_DATA_LEN_RELAY 32
 #define MAX_MQTT_DATA_THERMOSTAT 64
 #define MAX_MQTT_DATA_SCHEDULER 64
-#define JSON_BAD_RELAY_ID 255
 #define JSON_BAD_RELAY_VALUE 255
+#define JSON_BAD_TOPIC_ID 255
 
 #include "mqtt_client.h"
 
@@ -22,7 +22,7 @@ void handle_mqtt_sub_pub(void* pvParameters);
 char get_relay_json_value(const char* tag, esp_mqtt_event_handle_t event);
 
 
-char get_relay_id(esp_mqtt_event_handle_t event, const char * relayTopic);
+char get_topic_id(esp_mqtt_event_handle_t event, int maxTopics, const char * topic);
 
 bool handle_scheduler_mqtt_event(esp_mqtt_event_handle_t event);
 bool handle_relay_cfg_mqtt_event(esp_mqtt_event_handle_t event);

--- a/main/app_relay.h
+++ b/main/app_relay.h
@@ -5,14 +5,14 @@
 
 struct RelayCmdMessage
 {
-    char relayId;
-    char relayValue;
+    unsigned char relayId;
+    unsigned char relayValue;
 };
 
 struct RelayCfgMessage
 {
-    char relayId;
-    char onTimeout;
+    unsigned char relayId;
+    unsigned char onTimeout;
 };
 
 void publish_all_relays_data(esp_mqtt_client_handle_t client);

--- a/main/app_scheduler.h
+++ b/main/app_scheduler.h
@@ -1,14 +1,26 @@
 #ifndef APP_SCHEDULER_H
 #define APP_SCHEDULER_H
 
-void start_scheduler(void);
+#include "app_relay.h"
 
+void start_scheduler_timer(void);
+void handle_scheduler(void* pvParameters);
+
+#define RELAY_ACTION 1
+#define TRIGGER_ACTION 255
+#define MAX_SCHEDULER_NB 8
 //FIXME basic structure only
+
+union Data {
+  struct RelayCmdMessage relayData;
+};
+
 struct SchedulerCfgMessage
 {
-  char schedulerTimestamp;
-  char schedulerRelayId;
-  char schedulerRelayState;
+  unsigned char schedulerId;
+  unsigned int timestamp;
+  unsigned char actionId;
+  union Data data;
 };
 
 

--- a/main/app_scheduler.h
+++ b/main/app_scheduler.h
@@ -9,17 +9,23 @@ void handle_scheduler(void* pvParameters);
 #define RELAY_ACTION 1
 #define TRIGGER_ACTION 255
 #define MAX_SCHEDULER_NB 8
+
+#define ACTION_STATE_DISABLED 0
+#define ACTION_STATE_ENABLED 1
+
 //FIXME basic structure only
 
 union Data {
-  struct RelayCmdMessage relayData;
+  struct RelayCmdMessage relayActionData;
+  struct TriggerData {time_t now;} triggerActionData;
 };
 
 struct SchedulerCfgMessage
 {
   unsigned char schedulerId;
-  unsigned int timestamp;
+  time_t timestamp;
   unsigned char actionId;
+  unsigned char actionState;
   union Data data;
 };
 


### PR DESCRIPTION
new scheduler task which waits on queue for one of:
 - triger action => parse scheduler array and do the actions (sent each 60 seconds from timer)
 - relay action => received from mqtt as new action fot specific scheduling slot (we have 8 of them)

`mosquitto_pub  -i testcmd -u testcmd -P 123edcvbn -h mqtt.iot.cipex.ro -p 8883 --capath /etc/ssl/certs/ -t esp8266/ground26/cfg/scheduler/4 -m '{"ts":1570823373, "aId":1, "aState":1, "data": {"relayId": 3, "relayValue": 0}}'`